### PR TITLE
change type to dateWithin to solve type clash with date

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ var Joi = require('joi').extend(require('joi-extension-date-within'));
 
 var schema = Joi.object({
   from: Joi.date().required(),
-  to: Joi.date().required().withinDays(10, Joi.ref('from'))
+  to: Joi.dateWithin().required().days(10, Joi.ref('from'))
 });
 
 var input = {

--- a/index.js
+++ b/index.js
@@ -5,11 +5,11 @@ var hoek = require('hoek');
 const dayms = 86400000;
 
 module.exports = {
-  name: 'date',
+  name: 'dateWithin',
   base: Joi.any(),
   language: {
-    withinDays: 'must be within {{days}} days of {{from}}',
-    withinDaysRefError: 'invalid Joi.ref in schema'
+    days: 'must be within {{days}} days of {{from}}',
+    daysRefError: 'invalid Joi.ref in schema'
   },
   coerce(value, state, options) {
     if(typeof this._from === 'undefined') {
@@ -21,16 +21,16 @@ module.exports = {
       this._from = hoek.reach(state.parent, this._from.key);
 
       if(typeof this._from === 'undefined') {
-        return this.createError('date.withinDaysRefError', {}, state, options);
+        return this.createError('dateWithin.daysRefError', {}, state, options);
       }
     }
 
-    return (Math.ceil((value - this._from) /dayms) > this._days) ? this.createError('date.withinDays', { v: value, days: this._days, from: this._from }, state, options) : true;
+    return (Math.ceil((value - this._from) /dayms) > this._days) ? this.createError('dateWithin.days', { v: value, days: this._days, from: this._from }, state, options) : true;
 
   },
   rules: [
     {
-      name: 'withinDays',
+      name: 'days',
       description(params) {
         return `Date should with within ${params.days} of ${params.from}`;
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-extension-date-within",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Adds within validation to enable you to specify how many days a from a value should be",
   "main": "index.js",
   "scripts": {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -9,22 +9,22 @@ describe('date-within', function() {
   describe('days', function() {
 
     it('should validate success [89 days]', function() {
-      expect(Joi.attempt(new Date(2015,2,31), Joi.date().withinDays(90, new Date(2015,0,1)))).to.be.true;
+      expect(Joi.attempt(new Date(2015,2,31), Joi.dateWithin().days(90, new Date(2015,0,1)))).to.be.true;
     });
 
     it('should validate success [90 days]', function() {
-      expect(Joi.attempt(new Date(2015,3,1), Joi.date().withinDays(90, new Date(2015,0,1)))).to.be.true;
+      expect(Joi.attempt(new Date(2015,3,1), Joi.dateWithin().days(90, new Date(2015,0,1)))).to.be.true;
     });
 
     it('should fail [91 days]', function() {
       expect(() => {
-        Joi.attempt(new Date(2015,3,2), Joi.date().withinDays(90, new Date(2015,0,1)));
+        Joi.attempt(new Date(2015,3,2), Joi.dateWithin().days(90, new Date(2015,0,1)));
       }).to.throw('must be within 90 days of');
     });
 
     it('should allow a Joi.ref to be used as the from value', function() {
       var schema = Joi.object({
-        to: Joi.date().required().withinDays(90, Joi.ref('from')),
+        to: Joi.dateWithin().required().days(90, Joi.ref('from')),
         from: Joi.date().required()
       });
 
@@ -41,7 +41,7 @@ describe('date-within', function() {
 
     it('should allow a nested Joi.ref to be used', function() {
       var schema = Joi.object({
-        to: Joi.date().required().withinDays(90, Joi.ref('somewhere.past')),
+        to: Joi.dateWithin().required().days(90, Joi.ref('somewhere.past')),
         somewhere: Joi.object({
           past: Joi.date().required()
         })
@@ -61,7 +61,7 @@ describe('date-within', function() {
 
     it('should fail if the joi.ref is invalid', function() {
       var schema = Joi.object({
-        to: Joi.date().required().withinDays(90, Joi.ref('idontexist')),
+        to: Joi.dateWithin().required().days(90, Joi.ref('idontexist')),
         from: Joi.date().required()
       });
 
@@ -79,12 +79,12 @@ describe('date-within', function() {
     it('should use date.now as the from if from is omitted', function() {
       expect(() => {
         // Now + 11 days.
-        Joi.attempt(new Date().valueOf() + (86400000 * 11), Joi.date().withinDays(10));
+        Joi.attempt(new Date().valueOf() + (86400000 * 11), Joi.dateWithin().days(10));
       }).to.throw('\"value\" must be within 10 days of');
     });
 
     it('should display the description', function() {
-      const schema = Joi.date().withinDays(10, Date.UTC(2017,0,1));
+      const schema = Joi.dateWithin().days(10, Date.UTC(2017,0,1));
       expect(schema.describe()).to.deep.equal({
         rules: [{
           arg: {
@@ -92,9 +92,9 @@ describe('date-within', function() {
             from: Date.UTC(2017, 0, 1)
           },
           description: "Date should with within 10 of " + Date.UTC(2017, 0, 1),
-          name: "withinDays"
+          name: "days"
         }],
-        type: "date"
+        type: "dateWithin"
       });
     });
   });


### PR DESCRIPTION
type changed due to clash with other modules new method to call this is: `Joi.dateWithin().days(90, new Date(2017,1,1));`